### PR TITLE
Fix shrug (¯\_(ツ)_/¯) reason

### DIFF
--- a/helpers/reasons.js
+++ b/helpers/reasons.js
@@ -23,7 +23,7 @@ export const REASONS_TO_NOT_DEPLOY = [
   'Nope',
   'Why?',
   'Did the tests pass? Probably not',
-  '¯\\_(ツ)_/¯',
+  '¯\_(ツ)_/¯',
   '😹',
   'No',
   'No. Breathe and count to 10, start again',


### PR DESCRIPTION
The shrug reason has an extra `\`.

Source: https://emojipedia.org/person-shrugging/