### PR TITLE
Fix for afternoon check

### DIFF
--- a/helpers/constans.js
+++ b/helpers/constans.js
@@ -28,7 +28,7 @@ export function dayHelper(time) {
   if (time.isThursdayAfternoon()) {
     return REASONS_FOR_THURSDAY_AFTERNOON
   }
-  if (time.isAfternoon() && !!time.isWeekend()) {
+  if (time.isAfternoon() && !time.isWeekend()) {
     return REASONS_FOR_AFTERNOON
   }
   if (time.isWeekend()) {


### PR DESCRIPTION
the ```isWeekend``` function returns a true if its weekend. So a ```!!time.isWeekend()``` will return false on a working day. This causes the afternoon check not to work.