### PR TITLE
Fix isWeekend() to correctly detect sunday

### DIFF
--- a/helpers/time.js
+++ b/helpers/time.js
@@ -67,6 +67,6 @@ export default class Time {
    * @return bool
    */
   isWeekend() {
-    return this.now().day() > 5
+    return this.now().day() == 6 || this.now().day() == 0
   }
 }


### PR DESCRIPTION
moment.day() returns a value between 0 and 6 where 0 is Sunday.
Fixes baires/shouldideploy#256