### PR TITLE
Adding Slack API endpoint

### DIFF
--- a/helpers/constans.js
+++ b/helpers/constans.js
@@ -9,6 +9,24 @@ import {
   REASONS_FOR_WEEKEND
 } from './reasons'
 
+export const HOST = 'https://shouldideploy.today'
+
+export const shouldIDeploy = function (time) {
+  return time && !time.isFriday() && !time.isWeekend()
+}
+
+export const shouldIDeployAnswerImage = function (time) {
+  return shouldIDeploy(time) ? `${HOST}/yes.png` : `${HOST}/no.png`
+}
+
+export const shouldIDeployColorTheme = function (time) {
+  return shouldIDeploy(time) ? '#36a64f' : '#ff4136'
+}
+
+export const shouldIDeployFavIcon = function (time) {
+  return shouldIDeploy(time) ? `${HOST}/dots.png` : `${HOST}/dots-red.png`
+}
+
 export const getRandom = function ranDay(list) {
   return list[Math.floor(Math.random() * list.length)]
 }

--- a/helpers/time.js
+++ b/helpers/time.js
@@ -1,8 +1,10 @@
 import moment from 'moment-timezone'
 
 export default class Time {
+  static DEFAULT_TIMEZONE = 'UTC'
+
   constructor(timezone) {
-    this.timezone = timezone || 'UTC'
+    this.timezone = timezone || Time.DEFAULT_TIMEZONE
   }
 
   /**
@@ -12,6 +14,14 @@ export default class Time {
    */
   static zoneExists(timezone) {
     return moment.tz.zone(timezone) !== null
+  }
+
+  static validOrNull(timezone) {
+    if (!timezone) {
+      timezone = Time.DEFAULT_TIMEZONE
+    }
+
+    return this.zoneExists(timezone) ? new Time(timezone) : null
   }
 
   /**

--- a/now.json
+++ b/now.json
@@ -5,6 +5,10 @@
     "trailingSlash": false,
     "redirects": [
         {
+            "source": "/api/slack/(.*)",
+            "destination": "/api/slack"
+        },
+        {
             "source": "/api/(.*)",
             "destination": "/api"
         }

--- a/pages/api/index.js
+++ b/pages/api/index.js
@@ -1,8 +1,8 @@
 import Time from '../../helpers/time'
-import { getRandom, dayHelper } from '../../helpers/constans'
+import { getRandom, dayHelper, shouldIDeploy } from '../../helpers/constans'
 
 export default (req, res) => {
-  let timezone = req.query.tz || 'UTC'
+  let timezone = req.query.tz || Time.DEFAULT_TIMEZONE
 
   if (!Time.zoneExists(timezone)) {
     return res.status(400).json({
@@ -17,7 +17,7 @@ export default (req, res) => {
 
   res.status(200).json({
     timezone: timezone,
-    shouldideploy: !time.isFriday() && !time.isWeekend(),
+    shouldideploy: shouldIDeploy(time),
     message: getRandom(dayHelper(time))
   })
 }

--- a/pages/api/slack/index.js
+++ b/pages/api/slack/index.js
@@ -1,0 +1,28 @@
+import {
+  getRandom,
+  dayHelper,
+  shouldIDeployAnswerImage,
+  shouldIDeployColorTheme,
+  shouldIDeployFavIcon
+} from '../../../helpers/constans'
+import Time from '../../../helpers/time'
+
+export default (req, res) => {
+  let timezone = req.body.text || req.query.tz || Time.DEFAULT_TIMEZONE
+  let time = Time.validOrNull(timezone)
+
+  res.status(200).json({
+    response_type: time ? 'in_channel' : 'ephemeral',
+    attachments: [
+      {
+        text: time
+          ? getRandom(dayHelper(time))
+          : `Invalid time zone: '${timezone}'`,
+        color: shouldIDeployColorTheme(time),
+        thumb_url: shouldIDeployAnswerImage(time),
+        footer_icon: shouldIDeployFavIcon(time),
+        footer: 'Should I deploy today' + (time ? ` | ${timezone}` : '')
+      }
+    ]
+  })
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,10 @@
 import React from 'react'
 import Head from 'next/head'
+import {
+  shouldIDeploy,
+  shouldIDeployFavIcon,
+  shouldIDeployAnswerImage
+} from '../helpers/constans'
 import Time from '../helpers/time'
 import Widget from '../component/widget'
 import Footer from '../component/footer'
@@ -50,24 +55,20 @@ class Page extends React.Component {
           <link
             rel="icon"
             type="image/png"
-            href={
-              this.state.now.isFriday()
-                ? 'https://shouldideploy.today/dots-red.png'
-                : 'https://shouldideploy.today/dots.png'
-            }
+            href={shouldIDeployFavIcon(this.state.now)}
             sizes="32x32"
           />
           <meta
             property="og:image"
-            content={
-              this.state.now.isFriday()
-                ? 'https://shouldideploy.today/no.png'
-                : 'https://shouldideploy.today/yes.png'
-            }
+            content={shouldIDeployAnswerImage(this.state.now)}
           />
           <title>Should I Deploy Today?</title>
         </Head>
-        <div className={`wrapper ${this.state.now.isFriday() && 'its-friday'}`}>
+        <div
+          className={`wrapper ${
+            !shouldIDeploy(this.state.now) && 'its-friday'
+          }`}
+        >
           <div className="aligner">
             <Widget now={this.state.now} />
             <div className="meta">


### PR DESCRIPTION
This is adding an endpoint that replies according to the expected Slack API protocol for slash commands.

With this it will be possible to create Slack apps that are able to respond to `/shouldideploy [tz]` with:
![image](https://user-images.githubusercontent.com/4688763/118029437-753d8680-b364-11eb-8743-290dce195b00.png)
![image](https://user-images.githubusercontent.com/4688763/118029592-99996300-b364-11eb-9474-807d33b2bef7.png)

Or in case of invalid `tz`:
![image](https://user-images.githubusercontent.com/4688763/118029471-7cfd2b00-b364-11eb-939e-dcc8d8ec89f1.png)

The `tz` can be configured via:
1. `req.body.text`: Command text, eg. `/shouldideploy Europe/Berlin`
2. `req.query.tz`: From the command configuration, you can already setup the host with the tz, eg. `https://shouldideploy.today/api/slack?tz=Europe%2FBerlin`
3. `Time.DEFAULT_TIMEZONE`: `UTC`

It is not easy to get the `tz` from the Slack slash command API, so we will need to keep it configurable like that, for whoever is using slack in a single region, they can already attach it on the query param, but users would also still be able to override it.

If whoever uses this with people from multiple zones, users will need to override always or use the default stipulated by the slack workspace. Another option would also be to create multiple slash commands for each common region, e.g 
* `/shouldideploy_eu`
* `/shouldideploy_us`
* ...

I've also added a couple of minor changes to make things more consistent, I'll point them out in the specific places, feel free to ask me to drop/change them.

Example of a Slack command config:
![image](https://user-images.githubusercontent.com/4688763/118032203-ac616700-b367-11eb-9f11-6ed4ebd445f6.png)
*For local development, we must use ngrok to proxy Slack requests to our localhost server*

I guess you can create a simple Slack APP and publish it on their store, I believe no code is needed, you can do it only from the Slack API page, or people could also create inside their own workspace and configure as shown above.

Thanks!