### PR TITLE
Adding Slack API on footer

### DIFF
--- a/component/footer.js
+++ b/component/footer.js
@@ -38,5 +38,10 @@ export default (props) => (
         <mark>New API</mark>
       </a>
     </li>
+    <li>
+      <a href={'/api/slack?tz=' + props.timezone}>
+        <mark>New Slack API</mark>
+      </a>
+    </li>
   </ul>
 )


### PR DESCRIPTION
Forgot to add this to the footer on the last PR.

Not sure how we should go about docs for this though.
The link redirected to a doc page in the app or to a README?

Let me know what do you think