### PR TITLE
Add new date parameter. Add aditional docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ https://shouldideploy.today/api?tz=America/New_York&date=2023-03-31
 The API returns a JSON object containing the following keys:
 
 - `timezone`: The timezone used for evaluating the date and time.
+- `date`: The date provided as parameter in ISO format (YYYY-MM-DDTHH:mm:ss.sssZ)
 - `shouldideploy`: A boolean value indicating whether you should deploy today or not.
 - `message`: A string containing a reason or explanation for the `shouldideploy` result.
 
@@ -63,6 +64,7 @@ Example response:
 ```
 {
   "timezone": "UTC",
+  "date": "2023-03-31T00:00:00.000Z",
   "shouldideploy": false,
   "message": "It's Friday, better not deploy today."
 }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,57 @@ Reasons are located under [reasons.ts](https://github.com/baires/shouldideploy/b
 ## API endpoint
 There is an enpoint to use on your CI or just for fun at `https://shouldideploy.today/api`
 
+You can also provide optional parameters to customize the API response:
+
+- `tz`: The timezone to use when evaluating the date and time. The default value is UTC. Pass a valid timezone string, such as `America/New_York` or `Europe/London` default `UTC`.
+- `date`: The date to evaluate. The default value is the current date. Pass a valid date string in the format `YYYY-MM-DD`, such as `2023-03-31`.
+
+### Examples
+
+Get the default API response using the current date and time in the UTC timezone:
+
+
+```
+https://shouldideploy.today/api
+```
+
+Get the API response for a specific timezone (e.g., Europe/London):
+
+```
+https://shouldideploy.today/api?tz=Europe/London
+```
+
+Get the API response for a specific date (e.g., 2023-03-31) in the UTC timezone:
+
+```
+https://shouldideploy.today/api?date=2023-03-31
+```
+
+Get the API response for a specific date (e.g., 2023-03-31) in a specific timezone (e.g., America/New_York):
+
+```
+https://shouldideploy.today/api?tz=America/New_York&date=2023-03-31
+```
+
+## API Response
+
+The API returns a JSON object containing the following keys:
+
+- `timezone`: The timezone used for evaluating the date and time.
+- `shouldideploy`: A boolean value indicating whether you should deploy today or not.
+- `message`: A string containing a reason or explanation for the `shouldideploy` result.
+
+Example response:
+
+```
+{
+  "timezone": "UTC",
+  "shouldideploy": false,
+  "message": "It's Friday, better not deploy today."
+}
+```
+
+
 ## Community projects
  - [gustamms/devo-fazer-deploy-hoje](https://github.com/gustamms/devo-fazer-deploy-hoje) Versão brasileira do site https://shouldideploy.today/
  - [timelfrink/shouldideploy-action](https://github.com/timelfrink/shouldideploy-action) This action checks the website shouldideploy.today and stops deployments if the site tells us not to do so.

--- a/helpers/constans.ts
+++ b/helpers/constans.ts
@@ -14,8 +14,18 @@ import {
 
 export const HOST = 'https://shouldideploy.today'
 
-export const shouldIDeploy = function (time: Time | null) {
-  return time && !time.isFriday() && !time.isWeekend() && !time.isHolidays()
+export const shouldIDeploy = function (time: Time | null, date?: Date) {
+  if (!time) {
+    return false
+  }
+
+  const currentDate = time.getDate()
+
+  if (date && currentDate.toDateString() !== date.toDateString()) {
+    return false
+  }
+
+  return !time.isFriday() && !time.isWeekend() && !time.isHolidays()
 }
 
 export const shouldIDeployAnswerImage = function (time: Time | null) {

--- a/helpers/time.ts
+++ b/helpers/time.ts
@@ -1,9 +1,30 @@
 export default class Time {
   static DEFAULT_TIMEZONE = 'UTC'
   timezone: string
+  customDate: Date | null
 
-  constructor(timezone: string) {
+  constructor(timezone: string, customDate?: string) {
     this.timezone = timezone || Time.DEFAULT_TIMEZONE
+    if (customDate) {
+      const utcDate = new Date(customDate + 'T00:00:00Z')
+      const offset = utcDate.getTimezoneOffset() * 60 * 1000
+      const adjustedDate = new Date(utcDate.getTime() + offset)
+      this.customDate = adjustedDate
+    } else {
+      this.customDate = null
+    }
+  }
+
+  customDate?: Date
+
+  getDate(): Date {
+    if (this.customDate) {
+      return this.customDate
+    }
+    let timeZoneDate = new Date().toLocaleString('en-US', {
+      timeZone: this.timezone
+    })
+    return new Date(timeZoneDate)
   }
 
   /**
@@ -33,6 +54,9 @@ export default class Time {
    * @return {Date}
    */
   now(): Date {
+    if (this.customDate) {
+      return this.customDate
+    }
     let timeZoneDate = new Date().toLocaleString('en-US', {
       timeZone: this.timezone
     })
@@ -44,7 +68,7 @@ export default class Time {
    * @return boolean
    */
   isThursday(): boolean {
-    return this.now().getDay() === 4
+    return this.getDate().getDay() === 4
   }
 
   /**
@@ -52,7 +76,7 @@ export default class Time {
    * @return boolean
    */
   isFriday(): boolean {
-    return this.now().getDay() === 5
+    return this.getDate().getDay() === 5
   }
 
   /**
@@ -60,7 +84,7 @@ export default class Time {
    * @return boolean
    */
   is13th(): boolean {
-    return this.now().getDate() === 13
+    return this.getDate().getDate() === 13
   }
 
   /**
@@ -68,7 +92,7 @@ export default class Time {
    * @return boolean
    */
   isAfternoon(): boolean {
-    return this.now().getHours() >= 16
+    return this.getDate().getHours() >= 16
   }
 
   /**
@@ -100,7 +124,7 @@ export default class Time {
    * @return boolean
    */
   isWeekend(): boolean {
-    return this.now().getDay() === 6 || this.now().getDay() === 0
+    return this.getDate().getDay() === 6 || this.getDate().getDay() === 0
   }
 
   /**
@@ -109,9 +133,9 @@ export default class Time {
    */
   isDayBeforeChristmas(): boolean {
     return (
-      this.now().getMonth() === 11 &&
-      this.now().getDate() === 24 &&
-      this.now().getHours() >= 16
+      this.getDate().getMonth() === 11 &&
+      this.getDate().getDate() === 24 &&
+      this.getDate().getHours() >= 16
     )
   }
 
@@ -120,7 +144,7 @@ export default class Time {
    * @returns boolean
    */
   isChristmas(): boolean {
-    return this.now().getMonth() === 11 && this.now().getDate() === 25
+    return this.getDate().getMonth() === 11 && this.getDate().getDate() === 25
   }
 
   /**

--- a/helpers/time.ts
+++ b/helpers/time.ts
@@ -15,8 +15,6 @@ export default class Time {
     }
   }
 
-  customDate?: Date
-
   getDate(): Date {
     if (this.customDate) {
       return this.customDate

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -9,6 +9,7 @@ export default (
         (response: {
           error?: { message: string; type: string; code: number }
           timezone?: string
+          date?: string
           shouldideploy?: boolean | null
           message?: string
         }): void
@@ -17,6 +18,7 @@ export default (
   }
 ) => {
   let timezone = req.query.tz || Time.DEFAULT_TIMEZONE
+  let customDate = req.query.date
 
   if (!Time.zoneExists(timezone)) {
     return res.status(400).json({
@@ -28,15 +30,13 @@ export default (
     })
   }
 
-  let time: Time
-  if (req.query.date) {
-    time = new Time(timezone, req.query.date)
-  } else {
-    time = new Time(timezone)
-  }
+  let time = customDate ? new Time(timezone, customDate) : new Time(timezone)
 
   res.status(200).json({
     timezone: timezone,
+    date: customDate
+      ? new Date(customDate).toISOString()
+      : time.now().toISOString(),
     shouldideploy: shouldIDeploy(time),
     message: getRandom(dayHelper(time))
   })

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -2,7 +2,7 @@ import Time from '../../helpers/time'
 import { getRandom, dayHelper, shouldIDeploy } from '../../helpers/constans'
 
 export default (
-  req: { query: { tz: string; date?: string } },
+  req: { query: { tz: string; date: string } },
   res: {
     status: (response: number) => {
       json: {
@@ -29,32 +29,8 @@ export default (
   }
 
   let time: Time
-
   if (req.query.date) {
-    const inputDate = new Date(req.query.date)
-
-    if (isNaN(inputDate.getTime())) {
-      return res.status(400).json({
-        error: {
-          message: `Invalid date format. Expected a valid date string.`,
-          type: 'Bad Request',
-          code: 400
-        }
-      })
-    }
-
-    // Extend the Time class to accept the optional date parameter
-    class CustomTime extends Time {
-      constructor(timezone: string, date?: Date) {
-        super(timezone)
-        if (date) {
-          this.now = () =>
-            new Date(date.toLocaleString('en-US', { timeZone: timezone }))
-        }
-      }
-    }
-
-    time = new CustomTime(timezone, inputDate)
+    time = new Time(timezone, req.query.date)
   } else {
     time = new Time(timezone)
   }


### PR DESCRIPTION
Firsrt aprroach to add data paramenter, related to [874](https://github.com/baires/shouldideploy/issues/874)

This PR introduces the ability to specify custom dates and timezone adjustments in the API. Users can now provide a custom date and timezone to receive accurate shouldideploy results based on their input parameters. This enhancement greatly improves the flexibility and usefulness of the shouldideploy API.