### PR TITLE
Fix: fixed response to slack_api if it's afternoon

### DIFF
--- a/helpers/constans.ts
+++ b/helpers/constans.ts
@@ -25,7 +25,7 @@ export const shouldIDeploy = function (time: Time | null, date?: Date) {
     return false
   }
 
-  return !time.isFriday() && !time.isWeekend() && !time.isHolidays()
+  return !time.isFriday() && !time.isWeekend() && !time.isHolidays() && !time.isAfternoon()
 }
 
 export const shouldIDeployAnswerImage = function (time: Time | null) {


### PR DESCRIPTION
Fixed response to be the same as the text

Before:
![image](https://user-images.githubusercontent.com/56637084/233455700-98fef8cc-ed15-4465-890c-199603bdf54e.png)

After:
![image](https://user-images.githubusercontent.com/56637084/233456693-5ef0fec3-ca08-4713-965d-1122771c2173.png)

Helpers: @mateustozoni and @Lucaswhy