### PR TITLE
fix reason word break causing paddings

### DIFF
--- a/style.css
+++ b/style.css
@@ -192,6 +192,8 @@ ul.footer-list select {
 
 .reason {
   white-space: pre-line;
+  text-wrap: balance;
+  word-break: break-word;
   padding: 0 6rem;
 }
 


### PR DESCRIPTION
Before:
<img width="288" alt="Screenshot 2024-10-11 at 14 20 41" src="https://github.com/user-attachments/assets/9970ae64-d67d-4802-9e24-08396adf6851">


After:
<img width="287" alt="Screenshot 2024-10-11 at 14 20 47" src="https://github.com/user-attachments/assets/b1a45523-aed3-439f-b85b-cec0da9813a2">
