### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/coverage/lcov-report/sorter.js
+++ b/coverage/lcov-report/sorter.js
@@ -1,6 +1,17 @@
 /* eslint-disable */
 var addSorting = (function() {
     'use strict';
+
+    // Utility function to escape HTML special characters
+    function escapeHTML(str) {
+        if (!str) return '';
+        return str
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
     var cols,
         currentSort = {
             index: 0,
@@ -88,6 +99,8 @@ var addSorting = (function() {
             val = colNode.getAttribute('data-value');
             if (col.type === 'number') {
                 val = Number(val);
+            } else {
+                val = escapeHTML(val);
             }
             data[col.key] = val;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/baires/shouldideploy/security/code-scanning/3](https://github.com/baires/shouldideploy/security/code-scanning/3)

To fix the issue, we need to ensure that the value retrieved from `colNode.getAttribute('data-value')` is sanitized or escaped before being stored in the `data` object. This can be achieved by using a utility function to escape any potentially dangerous characters (e.g., `<`, `>`, `&`, `"`). This ensures that even if an attacker injects malicious content into the `data-value` attribute, it will not be interpreted as executable HTML or JavaScript.

The fix involves:
1. Adding a utility function to escape HTML special characters.
2. Applying this function to the value retrieved from `colNode.getAttribute('data-value')` before storing it in the `data` object.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
